### PR TITLE
chore(linguist): exclude ReScript from language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -46,3 +46,5 @@
 Cargo.lock linguist-generated=true
 package-lock.json linguist-generated=true
 mix.lock linguist-generated=true
+# Pending estate-wide policy: hide ReScript from primary-language detection.
+**/*.res linguist-detectable=false


### PR DESCRIPTION
Estate-wide policy: ReScript is being migrated to AffineScript. Pending mechanical migration; this PR is the immediate cosmetic fix to stop ReScript dominating GitHub's primary-language detection until the source files are ported.

Part of estate-wide metadata cleanup 2026-05-26.