### PR TITLE
chore(ci): replace mirror.yml with reusable wrapper

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,42 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0
-name: Mirror to GitLab and Bitbucket
+name: Mirror to Git Forges
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   mirror:
-    name: Sync to Forges
-    runs-on: ubuntu-latest
-    if: vars.GITLAB_MIRROR_ENABLED == 'true' || vars.BITBUCKET_MIRROR_ENABLED == 'true'
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          fetch-depth: 0
-
-      - name: Mirror to GitLab
-        if: vars.GITLAB_MIRROR_ENABLED == 'true' && secrets.GITLAB_SSH_KEY != ''
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.GITLAB_SSH_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
-          git remote add gitlab git@gitlab.com:hyperpolymath/error-lang.git || true
-          git push --mirror gitlab
-
-      - name: Mirror to Bitbucket
-        if: vars.BITBUCKET_MIRROR_ENABLED == 'true' && secrets.BITBUCKET_SSH_KEY != ''
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.BITBUCKET_SSH_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan bitbucket.org >> ~/.ssh/known_hosts
-          git remote add bitbucket git@bitbucket.org:hyperpolymath/error-lang.git || true
-          git push --mirror bitbucket
+    uses: hyperpolymath/standards/.github/workflows/mirror-reusable.yml@e6b2884722350515934d443daf23442f2195796f
+    secrets: inherit


### PR DESCRIPTION
Pins to hyperpolymath/standards#187 merge SHA e6b2884722350515934d443daf23442f2195796f. Replaces the canonical mirror.yml (~145 lines, drift-prone) with a thin ~13-line wrapper. Forge selection still externalised to vars.<FORGE>_MIRROR_ENABLED.

Part of estate-wide convergence campaign 2026-05-26 (standards#199 / #187).