### PR TITLE
chore(ci): replace scorecard.yml with reusable wrapper

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,41 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0
-name: OpenSSF Scorecard
+name: Scorecards supply-chain security
 
 on:
   branch_protection_rule:
   schedule:
-    - cron: '0 3 * * 1'  # Weekly on Monday
+    - cron: '23 4 * * 1'
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
 
 permissions: read-all
 
 jobs:
   analysis:
-    name: Scorecard Analysis
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      id-token: write
-      contents: read
-      actions: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          persist-credentials: false
-
-      - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3
-        with:
-          sarif_file: results.sarif
+    uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@e0caf11508a3989574713c78f5f444f2ce5e33ef
+    secrets: inherit


### PR DESCRIPTION
Pins to hyperpolymath/standards#205 merge SHA e0caf11508a3989574713c78f5f444f2ce5e33ef. Replaces the canonical scorecard.yml with a thin wrapper. Closes the 5-candidate convergence set (mirror, secret-scanner, codeql, hypatia-scan, scorecard).

Part of estate-wide convergence campaign 2026-05-26 (standards#199 / #205).