### PR TITLE
docs: seed CHANGELOG.md (Keep-a-Changelog format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
+-->
+
+# Changelog
+
+All notable changes to `error-lang` will be documented in this file.
+
+This file is generated from conventional commits by the
+[`changelog-reusable.yml`](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/changelog-reusable.yml)
+workflow (`hyperpolymath/standards#206`). Adopt the workflow in this repo's CI to keep this file in sync automatically — see
+[`templates/cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml)
+for the canonical config.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- feat: initial commit — Error-Lang paradox-embracing error handling language
+
+### Fixed
+
+- fix(ci): sync hypatia-scan.yml to canonical (kill cd-scanner build drift) (#3)
+- fix(ci): adopt canonical hypatia-scan.yml (env.HOME/scanner-layout + Comment-step gate) (#2)
+- fix(ci): adopt canonical hypatia-scan.yml (env.HOME/scanner-layout + Comment-step gate) (#1)
+- fix(ci): update hypatia binary detection in hypatia-scan workflow
+- fix(perms): restore exec bit on conformance runner scripts
+- fix(security): remove eval from conformance runner
+- fix: replace deno --allow-all with specific permission flags in LSP server
+
+### CI
+
+- ci: fix workflow-linter YAML parse error + self-flag bug
+- ci: wire hypatia-scan.yml to query own Dependabot alerts
+
+## Pre-history
+
+Prior commits to this file's introduction are recorded in git history but not formally classified into Keep-a-Changelog sections. To backfill, run `git cliff -o CHANGELOG.md` locally using the canonical [`cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml) — this is one-shot mechanical work.
+
+---
+
+<!-- This file was seeded by the 2026-05-26 estate tech-debt audit follow-up (Row-2 Phase 3); see [`hyperpolymath/standards/docs/audits/2026-05-26-estate-documentation-debt.md`](https://github.com/hyperpolymath/standards/blob/main/docs/audits/2026-05-26-estate-documentation-debt.md). -->


### PR DESCRIPTION
Closes Row-2 Phase 3 of the 2026-05-26 estate tech-debt audit chain for this repo. The 2026-05-26 documentation-debt audit (hyperpolymath/standards#197) flagged that 180 of 279 estate repos lacked a CHANGELOG.md (65% gap) — this seed closes that finding here.

The seed:
  - Uses Keep-a-Changelog format with an [Unreleased] section.
  - Buckets the most recent 100 commits by conventional-commit prefix (feat/fix/refactor/docs/ci/build) into Added/Fixed/Changed/ Documentation/CI sections.
  - References standards#206's changelog-reusable.yml + the canonical templates/cliff.toml for full-regeneration via git-cliff.

The file is initial — the maintainer can adopt changelog-reusable.yml in this repo's CI to keep it auto-regenerated, or regenerate manually.