### PR TITLE
chore(ci): bump standards reusable workflow pins

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   governance:
-    uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@e8fe153b568af5e3534a261eee0258fa84fa6c5e
+    uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   mirror:
-    uses: hyperpolymath/standards/.github/workflows/mirror-reusable.yml@e6b2884722350515934d443daf23442f2195796f
+    uses: hyperpolymath/standards/.github/workflows/mirror-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   scorecard:
-    uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@e8fe153b568af5e3534a261eee0258fa84fa6c5e
+    uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236


### PR DESCRIPTION
Bumps stale `hyperpolymath/standards/.github/workflows/*-reusable.yml` pins to current standards HEAD (`d135b05bfc647d0c0fbfedc7e80f37ea50f49236`) to clear governance 'Check Workflow Staleness' (ADR-003) failures. CI-pin changes only.

OWNER-AUTHORIZED estate pin-bump campaign 2026-06-24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)